### PR TITLE
remove busted terminology

### DIFF
--- a/js/startup.js
+++ b/js/startup.js
@@ -2204,7 +2204,6 @@ function prepare_settings() {
             'log_pv': [ON_OFF, 1, 'use livelog pv'],
             'popup_right_click': [ON_OFF, 1, 'right click on elements for a popup menu'],
             'reload_missing': [ON_OFF, 1],
-            'reverse_kills': [ON_OFF, 0],
             'rows_per_page': [[10, 20, 50, 100, 1000], 10],
             'scroll_inertia': option_number(0.95, 0, 0.99, 0.01),
             'wheel_adjust': option_number(63, 0, 240),


### PR DESCRIPTION
Change "Busted openings" to "Double wins" and "Double wins" to "Double kilsl", as per new TCEC nomenclatura.

Remove the toggle option "Reverse kills" from Options->Extra, which previously allowed to switch the displayed name from "Busted openings" to "Reverse kills".

Untested.